### PR TITLE
docs: expand README with installation and contribution sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,135 @@
 # PageRank
 A Python implementation of Google's famous PageRank algorithm.
 
-## Setup
+## Table of Contents
+- [Setup](#setup)
+  - [Dependencies](#dependencies)
+  - [Installation](#installation)
+- [Usage](#usage)
+- [Example Usage: TextRank](#example-usage-textrank)
+  - [TextRank Implementation](#textrank-implementation)
+    - [Function: textrank](#function-textrank)
+    - [Function: apply_text_rank](#function-apply-text-rank)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [License](#license)
 
-There's not much to it - just include the pagerank.py file in your project, make sure you've installed the dependencies listed below, and use away!
+## Setup
+There's not much to it - just include the `pagerank.py` file in your project, make sure you've installed the dependencies listed below, and use away!
 
 ### Dependencies
-
 This module relies on two relatively standard Python libraries:
 
-1.  [Numpy](http://www.numpy.org/) 
-2.  [Pandas](http://pandas.pydata.org/)
+1. [Numpy](http://www.numpy.org/)
+2. [Pandas](http://pandas.pydata.org/)
+
+### Installation
+Install the dependencies with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
 
 ## Usage
+The `pagerank` module exports one public function:
 
-The pagerank module exports one public function:
+```python
+power_iteration(transition_weights, rsp=0.15, epsilon=0.00001, max_iterations=1000)
+```
 
-     power_iteration(transition_weights, rsp=0.15, epsilon=0.00001, max_iterations=1000)
-     
-This function applies the PageRank algorithm to a provided graph to determine the steady probabilities with which a random walk through the graph will end up at each node. It does so using power iteration, an algorithm approximating steady state probabilities by iteratively improving them until convergence. This algorithm is guaranteed to converege to the correct steady state probabilities for ergodic Markov chains, which PageRank graphs are.
-  
-Arguments:
+This function applies the PageRank algorithm to a provided graph to determine the steady probabilities with which a random walk through the graph will end up at each node. It uses power iteration, an algorithm that iteratively refines the steady state probabilities until convergence. This algorithm is guaranteed to converge to the correct probabilities for ergodic Markov chains, which PageRank graphs are.
 
-| Name              | Type                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Optional? | Default Value |
-|-------------------|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------|
-| `transition_weights` | Once nested list or dictionary, or similar. | The graph to which the PageRank algorithm is applied represented as the weights between its nodes. It should be encoded sparsely as a once nested dictionary or a once nested list. If encoded sparsely as a once nested dictionary, keys and nested keys should correspond to node names and values to weights. Other datastructures with the same nested key-value interface, such as certain Pandas matrices, are also acceptable. If encoded as a once nested list, node names are assigned as the indices corresponding to locations in the nested list. | False    |            |
-| `rsp`               | `float`                                       | The graph to which the PageRank algorithm is applied represented as the weights between its nodes. It should be encoded sparsely as a once nested dictionary or a once nested list. If encoded sparsely as a once nested dictionary, keys and nested keys should correspond to node names and values to weights. Other datastructures with the same nested key-value interface, such as certain Pandas matrices, are also acceptable. If encoded as a once nested list, node names are assigned as the indices corresponding to locations in the nested list. | True     | `0.15`          |
-| `epsilon`           | `float`                                       | The threshold of convergence. If the Euclidean norm of the difference between the approximations of the steady state vector before and after an iteration of power iteration is smaller than epsilon, the algorithm will consider itself to have converged and will terminate.                                                                                                                                                                                                                                                                                | True     | `0.00001`       |
-| `max_iterations`     | `int`                                         | The number of iterations after which power iteration will be terminated even if it has not yet converged.                                                                                                                                                                                                                                                                                                                                                                                                                                                     | True     | `1000`          |
+### Arguments
 
-Note that elements of `transition_weights` need not be probabilities (meaning its rows need not be normalized), and the random surfer probabilities should not be incorporated into it. The `power_iteration` function will perform normalization and integration of the random surfer probabilities.
+| Name | Type | Description | Optional? | Default |
+|------|------|-------------|-----------|---------|
+| `transition_weights` | `dict` or `list` | Sparse representation of the graph as nested dicts or lists. Keys correspond to node names and values to weights. | No | — |
+| `rsp` | `float` | Random surfer probability controlling the chance of jumping to any node. | Yes | `0.15` |
+| `epsilon` | `float` | Threshold of convergence; iteration stops when successive approximations are closer than this value. | Yes | `0.00001` |
+| `max_iterations` | `int` | Maximum number of iterations before termination even without convergence. | Yes | `1000` |
 
-Return value: This function returns a Pandas series whose keys are node names and whose values are the corresponding steady state probabilities. This Pandas series can be treated as a dict.
+Note that elements of `transition_weights` need not be probabilities (rows need not be normalized), and the random surfer probabilities should not be incorporated into it. The `power_iteration` function will perform normalization and integrate the random surfer probabilities.
+
+Return value: This function returns a Pandas series whose keys are node names and whose values are the corresponding steady state probabilities. This series can be treated as a dict.
+
+Example usage:
+
+```python
+graph = {
+    "A": {"B": 1, "C": 1},
+    "B": {"C": 1},
+    "C": {"A": 1},
+}
+scores = power_iteration(graph)
+print(scores)
+```
 
 ## Example Usage: TextRank
+An implementation of TextRank and three sample stories are included as a demonstration of the PageRank module. TextRank is an unsupervised keyword significance scoring algorithm that applies PageRank to a graph built from words found in a document to determine the significance of each word. The `textrank` module, located in the `TextRank` directory, implements this algorithm.
 
-An implementation of TextRank and three stories one can apply it to are included as a sample usage of the PageRank module. TextRank is an unsupervised keyword significance scoring algorithm that applies PageRank to a graph built from words found in a document to determine the significance of each word. The textrank module, located in the TextRank directory, implements the TextRank algorithm.
+The module's main method applies TextRank to three fairy tales—Rapunzel, Cinderella and Beauty and the Beast—and prints out the results. To run this example, simply navigate to the `TextRank` directory and run:
 
-The textrank module's main method applies TextRank to three fairy tales, Rapunzel, Cinderalla and Beauty and the Beast. It then prints out the results, an ordered list of keywords and their associated significance scores. To run this example, simply navigate to the TextRank directory and run textrank.py:
+```bash
+python textrank/textrank.py
+```
 
-     python textrank/textrank.py
-     
 For more information about TextRank, see the [original paper](https://web.eecs.umich.edu/~mihalcea/papers/mihalcea.emnlp04.pdf) that proposed it.
 
 ### TextRank Implementation
+The `textrank` module also exports two public functions:
 
-The textrank module also exports two public functions:
-
-     textrank(document, window_size=2, rsp=0.15, relevant_pos_tags=["NN", "ADJ"])
-     apply_text_rank(file_name, title="a document")
+```python
+textrank(document, window_size=2, rsp=0.15, relevant_pos_tags=["NN", "ADJ"])
+apply_text_rank(file_name, title="a document")
+```
 
 #### Function: textrank
 
-     textrank(document, window_size=2, rsp=0.15, relevant_pos_tags=["NN", "ADJ"])
+```python
+textrank(document, window_size=2, rsp=0.15, relevant_pos_tags=["NN", "ADJ"])
+```
 
-The textrank function implements the TextRank algorithm. It creates a graph representing the document provided to it as an argument, applies the PageRank algorithm to that graph, and returns a list of words in the document sorted in descending order of resulting node weights. The graph representing the document is created using the words found in the document as nodes, and the frequency with which words co-occur in close proximity as weights. The node weights provided by the PageRank algorithm are considered to be the words' significance in the document.
+The `textrank` function implements the TextRank algorithm. It creates a graph representing the document provided to it as an argument, applies the PageRank algorithm to that graph, and returns a list of words in the document sorted in descending order of node weights. The graph representing the document is created using the words found in the document as nodes and the frequency with which words co-occur in close proximity as weights.
 
 Arguments:
 
-| Name            | Type      | Description                                                                                                                                                                                                                                                                    | Optional? | Default Value |
-|-----------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|---------------|
-| `document`        | `str`       | A string representing a document. Note that all characters in the string must be standard ASCII characters to avoid exceptions.                                                                                                                                                | False     |            |
-| `windowSize`      | `int`       | The width of the window in which two words must fall to be considered to have co-occured. For a window size of 2, the default value of this argument, a word will be considered to have co-occurred with any word one or two words away from it in the document.               | True      | `2`             |
-| `rsp`             | `float`     | Again the random surfer probability that represents the probability with which the random walk through the graph will deviate from its edges and instead jump randomly to any node in the graph.                                                                               | True      | `0.15`          |
-| `relevant_pos_tags` | `[str]` | The TextRank algorithm will filter the words in a document down to only those of certain parts of speech. The default implementation of the algorithm only considers nouns and adjectives. See the original paper that proposed TextRank for a justification of this decision. | True      | `["NN", "ADJ"]` |
-
+| Name | Type | Description | Optional? | Default |
+|------|------|-------------|-----------|---------|
+| `document` | `str` | A string representing a document. All characters must be standard ASCII to avoid exceptions. | No | — |
+| `window_size` | `int` | Width of the window in which two words must fall to be considered co-occurring. | Yes | `2` |
+| `rsp` | `float` | Random surfer probability that controls the chance of jumping to any node. | Yes | `0.15` |
+| `relevant_pos_tags` | `[str]` | Parts of speech to consider; by default nouns and adjectives. | Yes | `["NN", "ADJ"]` |
 
 Return Value: This function returns a list of words found in the document (filtered by parts of speech) in descending order of node weights.
 
 #### Function: apply_text_rank
 
-     apply_text_rank(file_name, title="a document")
+```python
+apply_text_rank(file_name, title="a document")
+```
 
-The applyTextRank function is a wrapper around the textrank function. It accepts a plain text document as its input, transfors that document into the data format expected by the textrank function, calls the textrank function to perform the textrank algorithm, and prints out the result cleanly along with a few helpful progress indicators.
+The `apply_text_rank` function is a wrapper around the `textrank` function. It accepts a plain text document as its input, transforms that document into the data format expected by the `textrank` function, calls `textrank` to perform the algorithm, and prints out the results along with progress indicators.
 
 Arguments:
 
-| Name     | Type                                        | Description                                                                                             | Optional? | Default Value |
-|----------|---------------------------------------------|---------------------------------------------------------------------------------------------------------|----------|---------------|
-| `file_name` | Once nested list or dictionary, or similar. | The name or full path of the file that contains the document the TextRank algorithm will be applied to. | False    |            |
-| `title`    | `str`                                         | The document's title, an optional argument used only in printed progress indicators.                    | True     | `"a document"`  |
+| Name | Type | Description | Optional? | Default |
+|------|------|-------------|-----------|---------|
+| `file_name` | `str` | Name or full path of the file that contains the document the TextRank algorithm will be applied to. | No | — |
+| `title` | `str` | The document's title, used only in printed progress indicators. | Yes | "a document" |
 
 Return value: This function has no return value, and instead prints out its results.
 
-If you would like to apply TextRank to a story or document of your choosing, add a plain text file containing the story to the TextRank directory and call the applyTextRank function, passing in the name of the file and optionally the document's title.
+If you would like to apply TextRank to a story or document of your choosing, add a plain text file containing the story to the `TextRank` directory and call the `apply_text_rank` function, passing in the name of the file and optionally the document's title.
+
+## Testing
+Run the test suite to verify that everything works as expected:
+
+```bash
+pytest -q
+```
+
+## Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request with improvements or bug fixes.
+
+## License
+This project is licensed under the [Apache 2.0](LICENSE) license.


### PR DESCRIPTION
## Summary
- add installation instructions and runnable example for `power_iteration`
- document testing steps, contribution guidelines, and license info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893da58ac548326a043897c927eadc8